### PR TITLE
--exclude option added

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,18 +55,20 @@ svn-extractor.py --url "url with .svn available"
 **alloptions**  
 
 python svnextractor.py --help  
-usage: svnextractor.py [-h] --url TARGET [--debug] [--noextract] [--userlist] [--wcdb] [--entries]  
+usage: svnextractor.py [-h] --url TARGET [--debug] [--noextract] [--userlist] [--wcdb] [--entries] [--match MATCH] [--exclude EXCLUDES]
 
 This program is used to extract the hidden SVN files from a webhost considering either .svn entries file (<1.6) or wc.db (> 1.7) are a actually automates the directory navigation and text extraction process  
 
 optional arguments:  
   -h, --help    show this help message and exit  
-  --url TARGET  Provide URL  
-  --debug       Provide debug information  
-  --noextract   Don't extract files just show content  
-  --userlist    show the usernames used for commit  
-  --wcdb        check only wcdb  
-  --entries     check only .svn/entries file  
+  --url TARGET        Provide URL  
+  --debug             Provide debug information  
+  --noextract         Don't extract files just show content  
+  --userlist          show the usernames used for commit  
+  --wcdb              check only wcdb  
+  --entries           check only .svn/entries file  
+  --match MATCH       only download files that match regex
+  --exclude EXCLUDES  exclude files with extensions separated by ','
   
 Credit (C) Anant Shrivastava http://anantshri.info Greets to Amol Naik, Akash Mahajan, Prasanna K, Lava Kumar for valuable inputs  
 


### PR DESCRIPTION
One may want to ignore some file types (like image, css) during extraction so I added this parameter.

Example usage goes like this:
python svn_extractor.py --url http://example.com --exclude jpg,jpeg,png,gif